### PR TITLE
 Fix bug: A system should be able to fit the details even a small screen or when user restore down (minimize size) of the page #74 

### DIFF
--- a/ui/src/app/shared/components/shared-patient-dashboard/shared-patient-dashboard.component.scss
+++ b/ui/src/app/shared/components/shared-patient-dashboard/shared-patient-dashboard.component.scss
@@ -23,7 +23,7 @@ button {
 }
 
 .patient-other-details-padding {
-  padding-top: 7rem;
+  padding-top: 140px !important;
 }
 
 .selected-form {

--- a/ui/src/app/shared/modules/form/components/field/field.component.scss
+++ b/ui/src/app/shared/modules/form/components/field/field.component.scss
@@ -34,7 +34,7 @@
   padding: 0 16px !important;
   padding-top: 70px !important;
   font-size: small;
-  padding-bottom: 2rem !important;
+  padding-bottom: 70px !important;
   text-align: left !important;
   text-decoration: none !important;
   max-width: 100% !important;

--- a/ui/src/app/shared/modules/form/components/field/field.component.scss
+++ b/ui/src/app/shared/modules/form/components/field/field.component.scss
@@ -33,6 +33,7 @@
   line-height: 30px !important;
   padding: 0 16px !important;
   padding-top: 2rem !important;
+  font-size: small;
   padding-bottom: 2rem !important;
   text-align: left !important;
   text-decoration: none !important;

--- a/ui/src/app/shared/modules/form/components/field/field.component.scss
+++ b/ui/src/app/shared/modules/form/components/field/field.component.scss
@@ -32,7 +32,7 @@
   display: block !important;
   line-height: 30px !important;
   padding: 0 16px !important;
-  padding-top: 2rem !important;
+  padding-top: 70px !important;
   font-size: small;
   padding-bottom: 2rem !important;
   text-align: left !important;

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -305,6 +305,7 @@ mat-dialog-container {
   z-index: 100;
   box-shadow: 0px 2px 1px -1px rgb(0 0 0 / 20%),
     0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%);
+  margin-top: 15px;
 }
 
 .patient-other-details-padding {


### PR DESCRIPTION
Fix 1:
Increasing padding-top and padding-bottom and reducing font size of dropdown menu options

File path:
icare/ui/src/app/shared/modules/form/components/field/field.component.scss

Changes:
::ng-deep .mat-option {
word-wrap: break-word !important;
white-space: pre-line !important;
border-bottom: 1px solid rgba(0, 0, 0, 0.125) !important;
text-overflow: ellipsis !important;
display: block !important;
line-height: 30px !important;
padding: 0 16px !important;
padding-top: 70px !important;
padding-bottom: 70px !important;
text-align: left !important;
font-size: small;
text-decoration: none !important;
max-width: 100% !important;
position: relative !important;
cursor: pointer !important;
outline: none !important;
display: flex !important;
flex-direction: row !important;
max-width: 100% !important;
box-sizing: border-box !important;
align-items: center !important;
-webkit-tap-highlight-color: transparent !important;
}

Fix 2:
adding margin-top on patient’s profile information

File path:
icare/ui/src/styles.scss

Changes:
.patient-profile-sticky {
margin-top: 15px;
width: 100%;
position: fixed;
z-index: 100;
box-shadow: 0px 2px 1px -1px rgb(0 0 0 / 20%),
0px 1px 1px 0px rgb(0 0 0 / 14%), 0px 1px 3px 0px rgb(0 0 0 / 12%);
}

Fix 3:
Increasing padding-top of patient’s other details and marking it important

File path:
icare/ui/src/app/shared/components/shared-patient-dashboard/shared-patient-dashboard.component.scss

Changes:
.patient-other-details-padding {
padding-top: 140px !important;
}