### PR TITLE
Added feature for issue #165: Supplier name, Invoice date and time in a receiving form in the main store | Group 19

### DIFF
--- a/ui/proxy-config.example.json
+++ b/ui/proxy-config.example.json
@@ -2,7 +2,6 @@
   "/": {
     "target": "https://icare.dhis2.udsm.ac.tz",
     "secure": "false",
-    "auth": "admin:Admin123",
     "changeOrigin": "true"
   }
 }

--- a/ui/src/app/modules/store/modals/add-new-stock-received/add-new-stock-received.component.ts
+++ b/ui/src/app/modules/store/modals/add-new-stock-received/add-new-stock-received.component.ts
@@ -55,6 +55,16 @@ export class AddNewStockReceivedComponent implements OnInit {
         value: "",
       }),
       new Textbox({
+        id: "time",
+        key: "time",
+        label: "Time",
+        type: "time",
+        controlType: "time",
+        required: true,
+        disabled: false,
+        value: "",
+      }),
+      new Textbox({
         id: "batchNo",
         key: "batchNo",
         label: "Batch NO",

--- a/ui/src/app/modules/store/modals/add-new-stock-received/add-new-stock-received.component.ts
+++ b/ui/src/app/modules/store/modals/add-new-stock-received/add-new-stock-received.component.ts
@@ -46,6 +46,15 @@ export class AddNewStockReceivedComponent implements OnInit {
         value: "",
       }),
       new Textbox({
+        id: "invoiceDate",
+        key: "invoiceDate",
+        label: "Invoice Date",
+        type: "text",
+        required: true,
+        disabled: false,
+        value: "",
+      }),
+      new Textbox({
         id: "batchNo",
         key: "batchNo",
         label: "Batch NO",

--- a/ui/src/app/modules/store/modals/add-new-stock-received/add-new-stock-received.component.ts
+++ b/ui/src/app/modules/store/modals/add-new-stock-received/add-new-stock-received.component.ts
@@ -37,6 +37,15 @@ export class AddNewStockReceivedComponent implements OnInit {
     // Create formfields
     this.formFields = [
       new Textbox({
+        id: "supplierName",
+        key: "supplierName",
+        label: "Supplier Name",
+        type: "text",
+        required: true,
+        disabled: false,
+        value: "",
+      }),
+      new Textbox({
         id: "batchNo",
         key: "batchNo",
         label: "Batch NO",


### PR DESCRIPTION
**PROBLEM**
Currently in the receiving form some of the information are missing including supplier details, date for receiving items.

**SOLUTION**
Step 1:
We traced the path of receiving form in the main store, [icare\ui\src\app\modules\store\modals\add-new-stock-received\add-new-stock-received.component.ts](url)

Step 2:
Modified in the receiving form in order to achieve all required details by adding 

- Supplier name field
- Invoice date field 
- Time of receiving items

Step 3:
Committing changes made by team members.

**ADDITIONAL CONTEXT**
Before modification:
![image](https://user-images.githubusercontent.com/83079451/215178668-4da1b0e7-2e8a-4c33-a119-1eb6c4dcf37e.png)

After modification:
![snipet](https://user-images.githubusercontent.com/83079451/215178970-3448ead7-ef0c-499d-a9b9-e84533c7c4c8.png)


GROUP MEMBERS:

1. KICHENJE, Francis HUSSEIN 2020-04-03808
2. GEOFREY, Mavula G. 2020-04-01934
3. Hashimu Udoddy Mbita 2020-04-12954
4. Mtagwaba, GLORIA K. 2020-04-08161
5. Ngowi, Nana Mwangaza 2020-04-09631
6. Bugaru, Abubakari R. 2020-04-00839