### PR TITLE
Added functionality to stop active visit #153

### DIFF
--- a/ui/src/app/modules/registration/pages/visit/visit.component.html
+++ b/ui/src/app/modules/registration/pages/visit/visit.component.html
@@ -114,6 +114,15 @@
           >
             Edit Visit
           </button> -->
+
+
+          <!-- Close visit added -->
+          <button mat-stroked-button 
+          (click)="closeVisit($event, params.activeVisitUuid)" 
+          class="mr-2">Close Visit</button>
+
+
+
           <button
             mat-stroked-button
             (click)="
@@ -707,6 +716,8 @@
             <button mat-stroked-button (click)="onCancel($event)">
               Cancel
             </button>
+
+
             <button
               mat-stroked-button
               class="ml-2"

--- a/ui/src/app/modules/registration/pages/visit/visit.component.ts
+++ b/ui/src/app/modules/registration/pages/visit/visit.component.ts
@@ -803,6 +803,125 @@ export class VisitComponent implements OnInit {
     }
   }
 
+
+
+  
+  // Close visit function
+
+  closeVisit(event:any, patientId) {
+    event.stopPropagation();
+
+    var currentTime = new Date();
+    var datetime = currentTime.toISOString();
+
+    if (true) {
+      let visitAttributes = [];
+      visitAttributes.push({
+        uuid: this.visitDetails?.Cash?.attributeUuid || null,
+        attributeType: "PSCHEME0IIIIIIIIIIIIIIIIIIIIIIIATYPE",
+        value:
+          this.visitDetails?.Cash && this.visitDetails?.Cash?.uuid
+            ? this.visitDetails?.Cash?.uuid
+            : this.visitDetails?.insuranceScheme?.uuid
+            ? this.visitDetails?.insuranceScheme?.uuid
+            : null,
+      });
+
+      if (this.visitDetails?.Insurance?.uuid) {
+        visitAttributes.push({
+          attributeType: "INSURANCEIIIIIIIIIIIIIIIIIIIIIIATYPE",
+          value: this.visitDetails?.Insurance?.uuid || null,
+        });
+
+        visitAttributes.push({
+          attributeType: "INSURANCEIDIIIIIIIIIIIIIIIIIIIIATYPE",
+          value: this.visitDetails?.InsuranceID || null,
+        });
+
+        visitAttributes.push({
+          attributeType: "INSURANCEAUTHNOIIIIIIIIIIIIIIIIATYPE",
+          value: this.visitDetails?.InsuranceAuthNo || null,
+        });
+      }
+
+      if (this.visitDetails?.emergency?.attributeUuid) {
+        visitAttributes.push({
+          uuid: this.visitDetails?.emergency?.attributeUuid,
+          value: this.visitDetails?.emergency?.value,
+          attributeType: "f0cfcd18-5fd1-4c1b-9447-dc0e56be66d4",
+        });
+      }
+
+      if (this.referralHospital != null) {
+        visitAttributes.push({
+          uuid: this.referralHospital?.attributeUuid,
+          attributeType: "47da17a9-a910-4382-8149-736de57dab18",
+          value: this.referralHospital.uuid,
+        });
+      }
+
+      let visitPayload = {
+        uuid: patientId,
+        visitType: this.visitDetails?.visitType?.uuid,
+        location: this.visitDetails?.Room?.uuid,
+        stopDatetime: datetime,
+        attributes: [
+          ...visitAttributes,
+          {
+            uuid: this.visitDetails?.Payment?.attributeUuid,
+            attributeType: "PTYPE000IIIIIIIIIIIIIIIIIIIIIIIATYPE",
+            value: this.visitDetails?.Payment?.uuid,
+          },
+          {
+            uuid: this.visitDetails?.service?.attributeUuid,
+            attributeType: "SERVICE0IIIIIIIIIIIIIIIIIIIIIIIATYPE",
+            value: this.visitDetails?.service?.uuid,
+          },
+          {
+            attributeType: "ebc0a258-44a1-409f-908c-652338c411e8",
+            value: this.visitDetails?.insuranceVisitType,
+          },
+          {
+            attributeType: "1ada2d4f-e6b7-4a5d-a2d0-d6d58e96ac7a",
+            value: this.visitDetails?.referralNo,
+          },
+          {
+            attributeType: "66f3825d-1915-4278-8e5d-b045de8a5db9",
+            value: this.visitDetails?.visitService,
+          },
+          {
+            attributeType: "6eb602fc-ae4a-473c-9cfb-f11a60eeb9ac",
+            value: this.visitDetails?.visitRoom,
+          },
+          {
+            attributeType: "370e6cf0-539f-46f1-87a2-43446d8b17b0",
+            value: this.visitDetails?.voteNumber,
+          },
+        ],
+      };
+      visitPayload = {
+        ...visitPayload,
+        attributes:
+          visitPayload?.attributes.filter((attribute) => attribute?.value) ||
+          [],
+      };
+
+      this.store.dispatch(
+        // updateVisit({ details: visitPayload, visitUuid: visitPayload?.uuid })
+        updateVisit({ visitUuid: visitPayload?.uuid, details: visitPayload })
+      );
+      this.visitUpdate.emit(visitPayload);
+    } else {
+      console.log("Error");
+      
+      this.openSnackBar("Error: location is not set", null);
+    }
+  }
+
+
+  // 
+
+
   getClaimForm(event, visitDetails): void {
     event.stopPropagation();
     this.visitUpdate.emit(null);
@@ -834,6 +953,7 @@ export class VisitComponent implements OnInit {
   }
 
   onSetEditPatient(event, path, patientUuid) {
+    this.editMode = true;
     event.stopPropagation();
     this.editPatient.emit(path + patientUuid);
   }


### PR DESCRIPTION
Addded feature according to issue #153
Hello @team,
We were able to add this new feature as instructed. The feature was to add a button that can stop an active patient visit.  GROUP MEMBERS:
INTISAAR ABDUL OTHMAN | 2020-04-10222 | BSc in CS
JORAM ALLAN KINGU | 2020-04-04092 | BSc in CS
ASYA OTHMAN IBRAHIM | 2020-04-02408 | BSc in CS
STELLA JAMES HANGI | 2020-04-02198 | BSc in CS
MUDATHIR ALAWI SAID | 2020-04-10908 | BSc in CS
Feature Tracing and placement
We were able to track where the feature buttons and codes should be placed by inspecting elements from the chrome browser in order to identify which element section shows when you select active visits. Then through that inspection we were able to trace the element that contained the data of active patient and add a button at the bottom that stop active patient. Challenges 
    • @angular/material failed to install components from the project which causes some of the pages not look good.
Adding the feature
Once the page that show patient data when active patient is clicked is found then we add new button at the bottom to stop active patient. The button is used to call the API found in openmrs in the visits category named ‘update visit’ which set the closing date of a particular patient to the current date and time. So once clicked it takes current date automatically and put it in a selected patient closing date thus ending their active visits. What we have done is adding a closing button and the function to handle visit closing as shown below.

![image](https://user-images.githubusercontent.com/84313223/215202818-3141e7ad-fc02-4d8e-90c1-855f6631444a.png)

![image](https://user-images.githubusercontent.com/84313223/215202862-10f40c02-fffb-45be-af01-b69188b551bc.png)
