### PR TITLE
Fixed the issue 238, by editing getSelectedPatient function in patient-tabular-list.component.ts, WILLIAM MDEMU 2021-04-06719

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng serve",
     "build": "ng build",
     "build:prod": "ng build --aot --configuration production",
     "test": "ng test",

--- a/ui/src/app/shared/components/patients-tabular-list/navigation-service.ts
+++ b/ui/src/app/shared/components/patients-tabular-list/navigation-service.ts
@@ -1,0 +1,35 @@
+
+import { Injectable, EventEmitter, Component, OnInit} from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+class NavigationService {
+  public navigateToNextPart = new EventEmitter<any>();
+
+  constructor() {}
+  public navigateToNext(part: string) {
+    this.navigateToNextPart.emit(part);
+  }
+}
+
+export class NavigationComponent {
+  constructor(private navigationService: NavigationService) {}
+
+  getSelectedPatient(event, patientVisitDetails) {
+    event.stopPropagation();
+    this.navigationService.navigateToNext('next-part');
+  }
+}
+
+
+export class PatienResultComponent implements OnInit {
+  constructor(private navigationService: NavigationService) {}
+
+  ngOnInit() {
+    this.navigationService.navigateToNextPart.subscribe((part: string) => {
+      //console.log(`Navigating to ${part}`);
+    });
+  }
+}
+

--- a/ui/src/app/shared/components/patients-tabular-list/patients-tabular-list.component.html
+++ b/ui/src/app/shared/components/patients-tabular-list/patients-tabular-list.component.html
@@ -1,3 +1,4 @@
+<!--This is the starting file for the bug #234-->
 <div>
   <table
     class="mat-elevation-z2"

--- a/ui/src/app/shared/components/patients-tabular-list/patients-tabular-list.component.ts
+++ b/ui/src/app/shared/components/patients-tabular-list/patients-tabular-list.component.ts
@@ -4,6 +4,8 @@ import { MatPaginator } from "@angular/material/paginator";
 import { MatTableDataSource } from "@angular/material/table";
 import { sanitizePatientsVisitsForTabularPatientListing } from "../../helpers/sanitize-visits-list-for-patient-tabular-listing.helper";
 import { Visit } from "../../resources/visits/models/visit.model";
+import { PatientLabResultsSummaryComponent } from "../patient-lab-results-summary/patient-lab-results-summary.component";
+//import { NavigationComponent } from './navigation-service';
 
 @Component({
   selector: "app-patients-tabular-list",
@@ -17,9 +19,9 @@ export class PatientsTabularListComponent implements OnInit, OnChanges {
   @Input() itemsPerPage: number;
   @Input() page: number;
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
-  @Output() patientVisitDetails: EventEmitter<any> = new EventEmitter<any>();
-  @Output() shouldLoadNewList: EventEmitter<boolean> =
-    new EventEmitter<boolean>();
+  //@Output() patientVisitDetails: EventEmitter<any> = new EventEmitter<any>();
+  @Output() patientLaboratoryResults: EventEmitter<any> = new EventEmitter<any>();
+  @Output() shouldLoadNewList: EventEmitter<boolean> = new EventEmitter<boolean>();
   currentPage: number = 0;
 
   displayedColumns: string[] = [
@@ -61,10 +63,14 @@ export class PatientsTabularListComponent implements OnInit, OnChanges {
     this.dataSource.paginator = this.paginator;
   }
 
-  getSelectedPatient(event, patientVisitDetails) {
+
+  getSelectedPatient(event, patientLaboratoryResults) {
     event.stopPropagation();
-    this.patientVisitDetails.emit(patientVisitDetails);
+    //The below line fixes the bug that has been caused by the code line commented below it 
+    this.patientLaboratoryResults.emit(PatientLabResultsSummaryComponent);
+    //this.patientVisitDetails.emit(patientVIsitDetails);
   }
+  
 
   applyFilter(event: Event) {
     const filterValue = (event.target as HTMLInputElement).value;


### PR DESCRIPTION
<h1>MDEMU, WILLIAM M, 2021-04-06710, Fixed issue 238</h1>
<h2><strong style="color:green;">Problem: </strong>Roll back as the <span>EventEmitter</span> emit function was emitting the incorrect class</h2><br/>
<p style="font-family:san-serif;">In the patient-tabular-list.component.ts there was a exported function called getSelectedPatient which was expected to return the lab result summary of the current (this) customer but instead the emit fuction of the Emmiter generic class was returning the patientVisitDetails which are found at the start page thus causing roll back so i have directed it to emit the patientLabSummaryResults and also commented the previous line of code.</p>
<hr>
<p style="font-family:san-serif;>I also added a typescript file called navigation-service.ts which i thought to use to create a route that will direct to patient lab results once clicked, if i would not figure that getSelectedPatient was the one that emits patientVisitDetail instead of patientLaboratoryResults.</p>