### PR TITLE
Added a new functionality feature enabling users attach more than one radiology attachment ( Reg No: 2021-04-09397, Name: Ndalahwa, Erick Samwel)

### DIFF
--- a/ui/src/app/modules/radiology/components/patient-radiology-orders-list/patient-radiology-orders-list.component.html
+++ b/ui/src/app/modules/radiology/components/patient-radiology-orders-list/patient-radiology-orders-list.component.html
@@ -68,6 +68,7 @@
                 accept=".pdf"
                 id="file-selector-{{ order?.concept?.uuid }}"
                 (change)="fileSelection($event, order)"
+                multiple
               />
 
               <button


### PR DESCRIPTION
Allows Multiple Selection: By adding the multiple attribute to the <input type="file"> element, you've enabled users to select multiple PDF files at once, instead of being limited to choosing only one file.

link to the issue: https://github.com/udsm-dhis2-lab/iCareConnect/issues/159