### PR TITLE
Discharged Patients filter based on issues #149

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,3 @@
 {
-  "name": "icare",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
+  "lockfileVersion": 1
 }

--- a/ui/src/app/modules/inpatient/pages/inpatient-home/inpatient-home.component.html
+++ b/ui/src/app/modules/inpatient/pages/inpatient-home/inpatient-home.component.html
@@ -18,7 +18,7 @@
   ></mat-progress-bar>
   <div *ngIf="params?.bedsByLocationDetails && params?.locationsIds">
     <mat-tab-group mat-align-tabs="start" dynamicHeight="true">
-      <mat-tab label="Patients">
+      <mat-tab label="Admitted Patients">
         <mat-toolbar>
           <button
             mat-icon-button
@@ -43,6 +43,7 @@
             <!-- TODO: Softcode the order uuid -->
             <!-- {{ locationsIds$ | async | json }} -->
             <app-patient-list
+                    [admissionState]="admissionStatus.ADMITTED"
               [encounterType]="'e22e39fd-7db2-45e7-80f1-60fa0d5a4378'"
               (selectPatient)="onSelectPatient($event)"
               [shouldShowParentLocation]="true"
@@ -71,6 +72,32 @@
           [currentLocation]="currentLocation"
           (bedStatus)="onGetBedStatus($event, params?.orderType)"
         ></app-wards-list>
+      </mat-tab>
+      <mat-tab label="Discharged Patients">
+        <mat-toolbar>
+          <button
+                    mat-icon-button
+                    (click)="onBack($event)"
+                    matTooltip="Go to Home page"
+                    >
+                  <mat-icon>arrow_back</mat-icon>
+                  <span class="ml-2" style="font-size: 1.2rem"
+                  >Discharged Patients</span>
+                  </button>
+        </mat-toolbar>
+        <div *ngIf="!params?.settingCurrentLocationStatus">
+          <div class="w-100 text-centered">
+            <!-- TODO: Softcode the order uuid -->
+            <!-- {{ locationsIds$ | async | json }} -->
+            <app-patient-list
+                    [admissionState]="admissionStatus.DISCHARGED"
+              [encounterType]="'e22e39fd-7db2-45e7-80f1-60fa0d5a4378'"
+              (selectPatient)="onSelectPatient($event)"
+              [shouldShowParentLocation]="true"
+              [isTabularList]="true"
+            ></app-patient-list>
+          </div>
+        </div>
       </mat-tab>
     </mat-tab-group>
   </div>

--- a/ui/src/app/modules/inpatient/pages/inpatient-home/inpatient-home.component.ts
+++ b/ui/src/app/modules/inpatient/pages/inpatient-home/inpatient-home.component.ts
@@ -28,6 +28,7 @@ import {
   getAllAdmittedPatientVisits,
   getVisitLoadingState,
 } from "src/app/store/selectors/visit.selectors";
+import {AdmissionStatus} from "../../../../shared/components/patient-list/patient-list.component";
 
 @Component({
   selector: "app-inpatient-home",
@@ -44,6 +45,8 @@ export class InpatientHomeComponent implements OnInit {
   orderType$: Observable<any>;
   settingCurrentLocationStatus$: Observable<boolean>;
   currentLocationUuid: string;
+
+  protected readonly AdmissionStatus = AdmissionStatus;
 
   constructor(
     private store: Store<AppState>,

--- a/ui/src/app/shared/components/patient-list/patient-list.component.html
+++ b/ui/src/app/shared/components/patient-list/patient-list.component.html
@@ -1,5 +1,5 @@
 <app-shared-error [errors]="errors"></app-shared-error>
-<div *ngIf="{ visits: visits$ | async } as params" class="w-100">
+<div *ngIf="{ visits: filteredVisits$ | async } as params" class="w-100">
   <div>
     <div class="search-input-card p-2 border mb-3 mt-3">
       <mat-icon matPrefix class="text-muted">search</mat-icon>


### PR DESCRIPTION
This pull request addresses the issues #149 in which we added the functionality to see discharged patients record and a new dedicated tab aimed at achieving such a feature.
- Minor Code refactors have also been done to the files concerned with this update
- The discharged patients tab still lacks a discharged at field in its table. This is cause by having less type information available in the interface and logging and breakpoints having little effects on observing OMODs data.