### PR TITLE
Issue #523, Bug has been fixed

### DIFF
--- a/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
+++ b/ui/src/app/shared/components/units-of-measure-settings/units-of-measure-settings.component.ts
@@ -98,5 +98,19 @@ export class UnitsOfMeasureSettingsComponent implements OnInit {
       });
   }
 
-  onEdit(concept: ConceptGet): void {}
+  onEdit(event: Event, drug): void {
+    this.dialog
+      .open(ManageUnitOfMeasureModalComponent, {
+        minWidth: "40%",
+        data: {
+         
+        },
+      })
+      .afterClosed()
+      .subscribe((shouldReloadData) => {
+        if (shouldReloadData) {
+          this.getUnitsOfMeasure();
+        }
+      });
+  }
 }


### PR DESCRIPTION
Bug that has to be fixed: Unit of Measure Dialog Data Issue

Issue Description and Summary:
The edit functionality for Unit of Measure was failing because the dialog component wasn't receiving the necessary data object when opened for the user to edit them.
After fixing a bug, editing was enabled and tested.

Root Cause:
The data object in the configuration was empty, preventing the editing component from accessing the current unit of measure details.

Solution:
We were able to modify the "onEdit" method to properly pass the drug data to the dialog component.

Participants:

Name: TAMAKILILO, Eliud Elia
Reg no. 2021-04-12129

Name: Mao, Raymond Paul
Reg no. 2022-04-06174

Name: Mponda, Glory Baraka
Reg no. 2022-04-08330

Name: Rwegasira, Theresia P
Reg no. 2022-04-11562
