### PR TITLE
Fixed lab results provider display bug

### DIFF
--- a/ui/src/app/shared/components/patient-history-data/patient-history-data.component.ts
+++ b/ui/src/app/shared/components/patient-history-data/patient-history-data.component.ts
@@ -187,13 +187,12 @@ export class PatientHistoryDataComponent implements OnInit {
     this.labOrders = visit.labOrders.map((order) => {
       return {
         ...order,
-        results: this.visit?.obs
-          ?.filter((ob) => {
-            if (order?.uuid == ob?.order?.uuid) {
-              return ob;
-            }
-          })
-          ?.filter((ob) => ob),
+          results: this.visit?.obs
+              ?.filter((ob) => order?.uuid === ob?.order?.uuid) // Match observations with the order's UUID
+              ?.map((ob) => ({
+                  ...ob,
+                  provider: ob?.fedBy || ob?.provider, // Prefer technician (fedBy) over doctor (provider)
+              })),
       };
     });
     this.radiologyOrders = visit.radiologyOrders.map((order) => {


### PR DESCRIPTION
**Bug Summary:**
The lab results in the patient history were incorrectly displaying the doctor's name instead of the technician who fed the results into the system.

**Cause:**
The `results` array for `labOrders` was not correctly prioritizing the `fedBy` property (technician) over the `provider` property (doctor). This caused the UI to show the doctor as the provider of the results.

**Fix:**
Updated the logic in `this.labOrders` mapping:
- Added a `map` transformation to ensure the `provider` field prioritizes the `fedBy` value.
- Simplified the filter logic to directly match orders and observations by UUID.

**Pull Request:**
[PR #529 - Fixed lab results provider display bug](https://github.com/udsm-dhis2-lab/iCareConnect/compare/main...G-first-t:iCareConnect:main?expand=1)

**Participants:**
- `2022-04-04347`: Gregory Kimbira
- `2022-04-12587`: Julius Ryoba
- `2022-04-10077`: Adrian Justine Ndossi
- `2022-04-09572`: kelvin Augustino
- `2022-04-05771`:  Samson Maige
