### PR TITLE
Fixing inconsistent room and tab selection upon back navigation within the all patients tab, particularly in room 4. #515

### DIFF
--- a/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.html
+++ b/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.html
@@ -141,7 +141,7 @@
           <mat-tab
             label="All Patients"
             *ngIf="
-              params?.showAllPatientsTab?.value === 'true' &&
+              params?.showAllPatientsTab?.value === 'true' ||
               (params?.userPrivileges['CLINIC_VIEW_ALL_CLIENTS'] ||
                 params?.userPrivileges['ALL'])
             "

--- a/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
+++ b/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
@@ -70,6 +70,10 @@ export class ClinicPatientListComponent implements OnInit {
     this.userPrivileges$ = this.store.select(getCurrentUserPrivileges);
 
     this.savedSelectedTab = localStorage.getItem("activeTab");
+
+    if(this.savedSelectedTab != null) {
+      this.selectedTab.setValue(parseInt(this.savedSelectedTab));
+    }
   }
 
   onSelectPatient(patient: any) {

--- a/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
+++ b/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
@@ -30,6 +30,7 @@ export class ClinicPatientListComponent implements OnInit {
   labTestOrderType$: Observable<any>;
   showAllPatientsTab$: Observable<any>;
   userPrivileges$: Observable<any>;
+  savedSelectedTab: any;
   constructor(
     private store: Store<AppState>,
     private systemSettingsService: SystemSettingsService,

--- a/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
+++ b/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
@@ -84,6 +84,7 @@ export class ClinicPatientListComponent implements OnInit {
 
   changeTab(index) {
     this.selectedTab.setValue(index);
+    localStorage.setItem("activeTab", index.toString());
     index == 0
       ? this.trackActionForAnalytics(`Awaiting Consultation : Open`)
       : index == 1

--- a/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
+++ b/ui/src/app/modules/clinic/pages/clinic-patient-list/clinic-patient-list.component.ts
@@ -68,6 +68,8 @@ export class ClinicPatientListComponent implements OnInit {
         `iCare.clinic.settings.patientsListGroups.showAllPatientsTab`
       );
     this.userPrivileges$ = this.store.select(getCurrentUserPrivileges);
+
+    this.savedSelectedTab = localStorage.getItem("activeTab");
   }
 
   onSelectPatient(patient: any) {
@@ -85,7 +87,7 @@ export class ClinicPatientListComponent implements OnInit {
 
   changeTab(index) {
     this.selectedTab.setValue(index);
-    localStorage.setItem("activeTab", index.toString());
+    localStorage.setItem("activeTab",; index.toString());
     index == 0
       ? this.trackActionForAnalytics(`Awaiting Consultation : Open`)
       : index == 1


### PR DESCRIPTION
**Fix Description**
This pull request addresses the inconsistency in room and tab selection when navigating back within the "All Patients" tab, specifically in Room 4. The issue was caused by the browser not retaining the previously selected tab index.

**Solution**
To resolve this, the implementation utilizes the browser's local storage to store the index of the last selected tab. Upon initializing the component, the stored tab index is retrieved, allowing the browser to automatically select the correct tab. This ensures consistent user experience during back navigation.

**Related Issue**
Resolves [#515](https://github.com/udsm-dhis2-lab/iCareConnect/issues/515)

**Link**
https://github.com/alfino77/iCareConnect/tree/group43

**Participants**
MAGANGA, Emmanuel Msoma 2022-04-05599
KAZIMOTO, Meshack Daniel 2022-04-03968
SEIF, Sabra Haroub 2022-04-12051
YUSUFU, Kauthar Abdul 2022-04-13449
ABDULLAH, Ahmed Khalfan 2022-04-00089